### PR TITLE
Fix emphasize-lines on example build.gradle

### DIFF
--- a/docs/ja/source/assemble.rst
+++ b/docs/ja/source/assemble.rst
@@ -79,7 +79,7 @@ Shafuを導入したEclipse環境では、デプロイメントアーカイブ�
 ..  code-block:: groovy
     :caption: build.gradle
     :name: build.gradle-1
-    :emphasize-lines: 8-9
+    :emphasize-lines: 7-8
 
     ...
     apply plugin: 'asakusafw-sdk'


### PR DESCRIPTION
## Summary
This PR fixes to wrong emphasize-lines on example build.gradle

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
