### PR TITLE
Fix emphasize-lines on example build.gradle

### DIFF
--- a/docs/ja/source/assemble.rst
+++ b/docs/ja/source/assemble.rst
@@ -118,7 +118,7 @@ Shafuを導入したEclipse環境では、デプロイメントアーカイブ�
 ..  code-block:: groovy
     :caption: build.gradle
     :name: build.gradle-4
-    :emphasize-lines: 4-6
+    :emphasize-lines: 3-5
 
     asakusafwOrganizer {
         profiles.prod {


### PR DESCRIPTION
## Summary
This PR fixes to wrong emphasize-lines on example build.gradle.
(follow-up #20)

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
