### PR TITLE
Change maven repository URL to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Basic tutorial documentation for [Asakusa Framework](https://github.com/asakusaf
 
 ## How to Build
 
-This tutorial uses the [Sphinx](http://www.sphinx-doc.org) documentation system.
+This tutorial uses the [Sphinx](https://www.sphinx-doc.org) documentation system.
 
-Building the documentation requires at least version 1.4 of [Sphinx](http://www.sphinx-doc.org) and the [Sphinx RTD Theme](https://pypi.python.org/pypi/sphinx_rtd_theme), [pygments-dmdl](https://pypi.python.org/pypi/pygments-dmdl) have to be installed.
+Building the documentation requires at least version 1.4 of [Sphinx](https://www.sphinx-doc.org) and the [Sphinx RTD Theme](https://pypi.python.org/pypi/sphinx_rtd_theme), [pygments-dmdl](https://pypi.python.org/pypi/pygments-dmdl) have to be installed.
 
 ```
 pip install sphinx

--- a/docs/ja/source/config-attachment/assemble-finished-build.gradle
+++ b/docs/ja/source/config-attachment/assemble-finished-build.gradle
@@ -2,7 +2,7 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.3'

--- a/docs/ja/source/config-attachment/default-build.gradle
+++ b/docs/ja/source/config-attachment/default-build.gradle
@@ -2,7 +2,7 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.3'

--- a/docs/ja/source/create-project.rst
+++ b/docs/ja/source/create-project.rst
@@ -56,7 +56,7 @@ Shafuを導入したEclipse環境では、ウィザードに従ってプロジ�
 
 Shafuを導入したEclipse以外の環境を利用する場合は、以下のURLに公開されているプロジェクトテンプレートをダウンロードして展開してください。
 
-* `asakusa-spark-template-0.10.3.tar.gz <http://www.asakusafw.com/download/gradle-plugin/asakusa-spark-template-0.10.3.tar.gz>`_
+* `asakusa-spark-template-0.10.3.tar.gz <https://www.asakusafw.com/download/gradle-plugin/asakusa-spark-template-0.10.3.tar.gz>`_
 
 IDEを利用する場合はこのプロジェクトをIDEにインポートしてください。
 

--- a/docs/ja/source/development-environment.rst
+++ b/docs/ja/source/development-environment.rst
@@ -19,10 +19,10 @@
     * - OS
       - Windows, MacOSX, Linux
       -
-    * - `JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_
+    * - `JDK <https://www.oracle.com/technetwork/java/javase/downloads/index.html>`_
       - JDK 8
       - JREは利用不可 [#]_
-    * - `Eclipse <http://www.eclipse.org/downloads/>`_
+    * - `Eclipse <https://www.eclipse.org/downloads/>`_
       - バージョン 4.4.2 以上
       -
     * - Excel

--- a/docs/ja/source/eclipse-shafu.rst
+++ b/docs/ja/source/eclipse-shafu.rst
@@ -60,7 +60,7 @@ Shafuのインストール
 Asakusa Frameworkには開発支援ツールを提供する :jinrikisha:`Jinrikisha <index.html>` というサブプロジェクトがあります。
 そこで公開しているツール :jinrikisha:`Shafu <shafu.html>` はAsakusa Frameworkのアプリケーション開発を支援するEclipseプラグインです。
 
-Asakusa Frameworkではアプリケーションのビルドに `Gradle <http://www.gradle.org/>`_ というビルドシステムを利用しますが、
+Asakusa Frameworkではアプリケーションのビルドに `Gradle <https://gradle.org/>`_ というビルドシステムを利用しますが、
 Shafuを使うことでGradleに関する詳細な知識がなくてもAsakusa Frameworkの基本的な開発作業が行えるようになります。
 また、コマンドライン上でのGradleの操作が不要となり、Eclipse上でアプリケーション開発に必要なほとんどの作業を行うことができるようになります。
 
@@ -76,7 +76,7 @@ Shafuは一般的なEclipseプラグインと同様の手順でEclipseにイン�
     * - :guilabel:`Name:`
       - ``Jinrikisha``
     * - :guilabel:`Location:`
-      - ``http://www.asakusafw.com/eclipse/jinrikisha/updates/``
+      - ``https://www.asakusafw.com/eclipse/jinrikisha/updates/``
 
 4. Install ダイアログに表示された :guilabel:`Jinrikisha (人力車)` カテゴリを展開して :guilabel:`Asakusa Gradle プラグインサポート` を選択し、 :guilabel:`Next >` ボタンを押下します。
 

--- a/docs/ja/source/readme.rst
+++ b/docs/ja/source/readme.rst
@@ -30,8 +30,8 @@
 Spark や関連する `Apache Hadoop`_ については本チュートリアルでは解説しませんので、
 この部分についてはSparkやHadoopの基本的な知識があることを前提としています。
 
-..  _`Apache Spark`: http://spark.apache.org/
-..  _`Apache Hadoop`: http://hadoop.apache.org/
+..  _`Apache Spark`: https://spark.apache.org/
+..  _`Apache Hadoop`: https://hadoop.apache.org/
 
 サンプルアプリケーション
 ========================


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from http to https in `pom.xml` and `build.gradle` for framework build configurations.
This also changes link URL to https in documentation files.

## Background, Problem or Goal of the patch
Follow-up asakusafw/asakusafw#845

## Design of the fix, or a new feature
The same as asakusafw/asakusafw#845

## Related Issue, Pull Request or Code
N/A.
