### PR TITLE
Bump Asakusa Framework version to 0.10.4

### DIFF
--- a/docs/ja/source/conf.py
+++ b/docs/ja/source/conf.py
@@ -39,13 +39,13 @@ extensions = [
 [extensions]
 
 extlinks = {
-    'asakusafw': ('https://docs.asakusafw.com/0.10.3/release/ja/html/%s',  None),
+    'asakusafw': ('https://docs.asakusafw.com/0.10.4/release/ja/html/%s',  None),
     'jinrikisha': ('https://docs.asakusafw.com/jinrikisha/ja/html/%s', None),
 }
 
 javadoclinks = {
-    'javadoc': ('https://docs.asakusafw.com/0.10.3/release/api/%s.html', ""),
-    'gradledoc': ('https://docs.asakusafw.com/0.10.3/release/gradle-plugins/%s.html', "")
+    'javadoc': ('https://docs.asakusafw.com/0.10.4/release/api/%s.html', ""),
+    'gradledoc': ('https://docs.asakusafw.com/0.10.4/release/gradle-plugins/%s.html', "")
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/ja/source/config-attachment/assemble-finished-build.gradle
+++ b/docs/ja/source/config-attachment/assemble-finished-build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.3'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4'
     }
 }
 

--- a/docs/ja/source/config-attachment/default-build.gradle
+++ b/docs/ja/source/config-attachment/default-build.gradle
@@ -5,7 +5,7 @@ buildscript {
         maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
     }
     dependencies {
-        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.3'
+        classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '0.10.4'
     }
 }
 

--- a/docs/ja/source/create-project.rst
+++ b/docs/ja/source/create-project.rst
@@ -32,7 +32,7 @@ Shafuを導入したEclipse環境では、ウィザードに従ってプロジ�
 ..  figure:: images/create-project-from-catalog.png
 
 4. プロジェクトテンプレート ダイアログにオンラインに公開されている、利用可能なプロジェクトテンプレートの一覧が表示されます。
-   ここでは、 :guilabel:`Asakusa Project Template <Spark> - 0.10.x` ( ``0.10.3`` など ) を選択して、 :guilabel:`OK` ボタンを押下します。
+   ここでは、 :guilabel:`Asakusa Project Template <Spark> - 0.10.x` ( ``0.10.4`` など ) を選択して、 :guilabel:`OK` ボタンを押下します。
 
 ..  figure:: images/create-project-select-template.png
 
@@ -56,7 +56,7 @@ Shafuを導入したEclipse環境では、ウィザードに従ってプロジ�
 
 Shafuを導入したEclipse以外の環境を利用する場合は、以下のURLに公開されているプロジェクトテンプレートをダウンロードして展開してください。
 
-* `asakusa-spark-template-0.10.3.tar.gz <https://www.asakusafw.com/download/gradle-plugin/asakusa-spark-template-0.10.3.tar.gz>`_
+* `asakusa-spark-template-0.10.4.tar.gz <https://www.asakusafw.com/download/gradle-plugin/asakusa-spark-template-0.10.4.tar.gz>`_
 
 IDEを利用する場合はこのプロジェクトをIDEにインポートしてください。
 

--- a/docs/ja/source/readme.rst
+++ b/docs/ja/source/readme.rst
@@ -37,7 +37,7 @@ Spark や関連する `Apache Hadoop`_ については本チュートリアル�
 ========================
 
 このチュートリアルで扱うサンプルアプリケーションはGitHubで公開しているサンプルアプリケーションプロジェクト
-`example-basic-spark <https://github.com/asakusafw/asakusafw-examples/tree/0.10.3/example-basic-spark>`_ をベースにしています。
+`example-basic-spark <https://github.com/asakusafw/asakusafw-examples/tree/0.10.4/example-basic-spark>`_ をベースにしています。
 完成したソースコードやプロジェクト構成を確認したい場合はこちらも参考にしてください。
 
 ドキュメントについて


### PR DESCRIPTION
## Summary
This PR bumps up Asakusa Framework version to 0.10.4 in some documents.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
